### PR TITLE
Fix List_of_translated_mods.md

### DIFF
--- a/List_of_translated_mods.md
+++ b/List_of_translated_mods.md
@@ -400,8 +400,6 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=1131405167
 # More Nations and Names WotC
 https://steamcommunity.com/sharedfiles/filedetails/?id=1124284135
 
-Note: for guaranteed work delete steamapps\workshop\content\268500\1124284135\Localization\RUS\XComGame.rus
-
 * Russian
 
 # [WOTC] Automated Loadout Manager

--- a/List_of_translated_mods.md
+++ b/List_of_translated_mods.md
@@ -303,6 +303,8 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=1316359865
 # [WoTC] ADVENT Military Assault MEC
 https://steamcommunity.com/sharedfiles/filedetails/?id=2755570022
 
+* Simplified Chinese
+
 # [WOTC] Advent Psi Ops
 https://steamcommunity.com/sharedfiles/filedetails/?id=1309465679
 
@@ -390,10 +392,10 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=2167235854
 
 * Russian
 
-# [WOTC] Purifier Grenades Fix
-https://steamcommunity.com/sharedfiles/filedetails/?id=1371195713
+# More Cities WotC
+https://steamcommunity.com/sharedfiles/filedetails/?id=1131405167
 
-* International English
+* Russian
 
 # More Nations and Names WotC
 https://steamcommunity.com/sharedfiles/filedetails/?id=1124284135
@@ -415,6 +417,7 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=1748331160
 # [WOTC] Purifier Grenades Fix
 https://steamcommunity.com/sharedfiles/filedetails/?id=1371195713
 
+* International English
 * Russian
 
 # [WOTC] Stabilize Me
@@ -434,11 +437,6 @@ https://steamcommunity.com/sharedfiles/filedetails/?id=1964595004
 
 # More Traits
 https://steamcommunity.com/sharedfiles/filedetails/?id=1122837889
-
-* Russian
-
-# More Cities WotC
-https://steamcommunity.com/sharedfiles/filedetails/?id=1131405167
 
 * Russian
 


### PR DESCRIPTION
1) duplicate of [WOTC] Purifier Grenades Fix
2) missed language from [#115](https://github.com/X2CommunitySupplemental/X2CommunityTranslation/issues/115) [WoTC] ADVENT Military Assault MEC
3) just put More Cities WotC next to More Nations and Names WotC
4) remove note for #More Nations and Names WotC (for guaranteed work delete file), as you said load order is correct.